### PR TITLE
Adds @storybook/storybook-deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ deskpro-components
 ==================
 A react-based set of components for building DeskPRO apps.
 
+A Storybook demo is available online at https://deskproapps.github.io/deskpro-components.
+
 ## Components
 
 * [Common/Popper](docs/components/common/popper.md)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:js": "eslint . --cache --cache-location=.cache/eslint --ext .js,.jsx",
     "test:visual": "start-storybook -p 9002 -c .storybook",
     "test:visual:build": "build-storybook -o build/storybook",
+    "deploy:storybook": "storybook-to-ghpages",
     "webpack": "webpack",
     "prepublish": "npm run compile"
   },
@@ -24,6 +25,7 @@
     "@storybook/addon-links": "^3.0.0",
     "@storybook/addon-notes": "^3.0.0",
     "@storybook/react": "3.0.1",
+    "@storybook/storybook-deployer": "^2.0.0",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.4.0",
     "babel-eslint": "^6.0.2",


### PR DESCRIPTION
As discussed in #10, adds storybook-deployer to publish the storybook to GH pages, and updates the readme with the URL.

https://deskproapps.github.io/deskpro-components